### PR TITLE
Fix Seeder Idempotency

### DIFF
--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -26,6 +26,7 @@ RUN npm run build
 RUN test -d dist || (echo "dist directory was not created during build" && exit 1)
 
 RUN npx prisma migrate deploy
+RUN npm run prod:db:seed
 
 FROM node:22.17 AS production
 ARG DATABASE_URL

--- a/server-app/prisma/seed.ts
+++ b/server-app/prisma/seed.ts
@@ -264,17 +264,38 @@ const customPatientWithAppointments: PatientCreateInput = {
   },
 }
 
+const seedPatientsOrSkip = async () => {
+  const patientsCount = await prisma.patient.count()
+  if (patientsCount < 50) {
+    return await prisma.patient.createMany({ data: fakePatients, skipDuplicates: true })
+  }
+  logger.info('Skipping patient seeding, already enough patients in the database.')
+}
+
+const seedProvidersOrSkip = async () => {
+  const providersCount = await prisma.provider.count()
+  if (providersCount < 20) {
+    return await prisma.provider.createMany({ data: fakeProviders, skipDuplicates: true })
+  }
+  logger.info('Skipping provider seeding, already enough providers in the database.')
+}
+
+const seedInsuranceProvidersOrSkip = async () => {
+  const insuranceProvidersCount = await prisma.insuranceProvider.count()
+  if (insuranceProvidersCount < 10) {
+    return await prisma.insuranceProvider.createMany({ data: fakeInsuranceProviders, skipDuplicates: true })
+  }
+  logger.info('Skipping insurance provider seeding, already enough insurance providers in the database.')
+}
+
 const seed = async () => {
   try {
     logger.info('Seeding database tables...')
 
+    await seedPatientsOrSkip(),
+    await seedProvidersOrSkip(),
+    await seedInsuranceProvidersOrSkip(),
     await prisma.$transaction([
-      prisma.patient.createMany({ data: fakePatients, skipDuplicates: true }),
-      prisma.provider.createMany({ data: fakeProviders, skipDuplicates: true }),
-      prisma.insuranceProvider.createMany({
-        data: fakeInsuranceProviders,
-        skipDuplicates: true,
-      }),
       prisma.patient.upsert({
         where: { email: customPatient.email },
         update: {}, // no update if it exists

--- a/server-app/prisma/seed.ts
+++ b/server-app/prisma/seed.ts
@@ -293,8 +293,6 @@ const seed = async () => {
     logger.info('Seeding database tables...')
 
     await seedPatientsOrSkip(),
-    await seedProvidersOrSkip(),
-    await seedInsuranceProvidersOrSkip(),
     await prisma.$transaction([
       prisma.patient.upsert({
         where: { email: customPatient.email },
@@ -311,6 +309,8 @@ const seed = async () => {
         skipDuplicates: true,
       }),
     ])
+    await seedProvidersOrSkip(),
+    await seedInsuranceProvidersOrSkip(),
     await prisma.provider.createMany({
       data: customProviders,
       skipDuplicates: true,


### PR DESCRIPTION
- Make sure seeder does not continue to fill dB with random patients, providers or insuranceProviders each time the seeder script is run
- Re-add the seeder script to the dockerfile to run on each deploy of server
- Closes #127 